### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/scripts/get_isbns.py
+++ b/scripts/get_isbns.py
@@ -2,7 +2,7 @@ import pymysql
 import re
 import requests
 from bs4 import BeautifulSoup
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 # INSERT INTO table1 VALUES(1, LOAD_FILE('data.png'));
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,8 +1,7 @@
 bs4
 captcha-solver
-fuzzywuzzy
 lxml
 mysql-connector == 2.1.4
 pymysql
-python-Levenshtein
+rapidfuzz
 requests


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy