### PR TITLE
Use https:// for accessing Sycamore in all environments. 

### DIFF
--- a/config/template.json.in
+++ b/config/template.json.in
@@ -45,7 +45,7 @@
 
   "sycamore-auth": {
     "school-id": "2132",
-    "url": "http://app.sycamoreschool.com/index.php",
+    "url": "https://app.sycamoreschool.com/index.php",
     "success-text": "schoolhome.php"
   },
 

--- a/provision/srv-salt/server/dev.json
+++ b/provision/srv-salt/server/dev.json
@@ -41,7 +41,7 @@
 
   "sycamore-auth": {
     "school-id": "2132",
-    "url": "http://app.sycamoreschool.com/index.php",
+    "url": "https://app.sycamoreschool.com/index.php",
     "success-text": "schoolhome.php"
   },
 

--- a/provision/srv-salt/server/files/public.json
+++ b/provision/srv-salt/server/files/public.json
@@ -36,7 +36,7 @@
 
   "sycamore-auth": {
     "school-id": "2132",
-    "url": "http://app.sycamoreschool.com/index.php",
+    "url": "https://app.sycamoreschool.com/index.php",
     "success-text": "schoolhome.php"
   }
 


### PR DESCRIPTION
Using plain http:// always results in a 301 redirect - even if the credentials are correct.